### PR TITLE
Better worker.py path for GitHub pages

### DIFF
--- a/examples/pubsub.py
+++ b/examples/pubsub.py
@@ -1,4 +1,4 @@
-# LTK - Copyright 2024 - All Rights Reserved - chrislaffra.com - See LICENSE 
+# LTK - Copyright 2024 - All Rights Reserved - chrislaffra.com - See LICENSE
 
 import ltk
 import random
@@ -6,7 +6,7 @@ from polyscript import XWorker
 
 # Workers only work when server sets CORS, COOP, COEP headers
 # See https://jeff.glass/post/whats-new-pyscript-2023-11-1/ for more details
-worker = XWorker("/examples/worker.py", config="/examples/worker.toml", type="micropython")
+worker = XWorker("./examples/worker.py", config="./examples/worker.toml", type="micropython")
 
 fan = ltk.Preformatted("")
 
@@ -20,12 +20,12 @@ ltk.subscribe(
 def publish(event=None):
     message = random.choice([
         "Subscribe!\n", "Like!\n", "Share!\n", "Pay me!\n", "Repost!\n"
-    ]) 
+    ])
     ltk.publish(
         "Influencer",   # the sender
         "Fan",          # the intended receiver
         "message",      # the subscription topic
-        message         # the message to send 
+        message         # the message to send
     )
 
 def create():


### PR DESCRIPTION
I have noticed the wrong absolute URL was not working on GitHub pages so I've fixed it.

I know it's not idea to not being able to refer to the current folder but the thing is that such file could be imported in the VFS at any path level so the root/starting folder is always the one that bootstraps the interpreter, not necessarily the one where the file is.

This has been tested locally and the network related errors are now gone, it should work on GitHub pages too.

P.S. there is another error about MicroPython but it seems unrelated to this change or the previous one with the Service Worker.