### PR TITLE
add more precise class name match

### DIFF
--- a/ltk/widgets.py
+++ b/ltk/widgets.py
@@ -626,7 +626,7 @@ class LocalStorageModel(Model):
         """ Load all models of this type from local storage """
         return [
             cls(key) for key in window.Object.keys(cls.__store)
-            if key.startswith(cls.__name__)
+            if key.startswith(f"{cls.__name__}-")
         ]
 
 


### PR DESCRIPTION
in an app I hat two classes of `LocalStorageModel` that were starting with the same characters: 
`class ABCFoo(LocalStorageModel):`
and
`class ABCFooBar(LocalStorageModel):`
it took me some time to understand why instances of `ABCFooBar` got loaded with the loader from `ABCFoo` and got the attributes `ABCFoo`.  
the proposed added `-` at the end of the startswith match check would prevent this. 😌 